### PR TITLE
Wrap query param in quotes when it's a string

### DIFF
--- a/kuestioner/build.gradle
+++ b/kuestioner/build.gradle
@@ -11,7 +11,7 @@ ext {
     siteUrl = 'https://github.com/thalescm/kuestioner'
     gitUrl = 'https://github.com/thalescm/kuestioner.git'
 
-    libraryVersion = '0.1.1'
+    libraryVersion = '0.1.2'
 
     developerId = 'thalescm'
     developerName = 'Thales Machado'

--- a/kuestioner/src/main/java/br/com/thalesmachado/kuestioner/logic/Logic.kt
+++ b/kuestioner/src/main/java/br/com/thalesmachado/kuestioner/logic/Logic.kt
@@ -38,7 +38,8 @@ internal fun getQueryForClass(clazz: Class<*>, queries: Map<String, Any>): Strin
     var parameters = parenthesisStart
     for (query: String in getQueriesParameterName(clazz)) {
         if (queries[query] != null) {
-            parameters += "$query:${queries[query]},"
+            val wrapInQuotes = if (queries[query] is String) "\"${queries[query]}\"" else queries[query]
+            parameters += "$query:$wrapInQuotes,"
         } else {
             throw IllegalArgumentException("${getClassName(clazz)} must have a value to query for $query")
         }

--- a/kuestioner/src/test/java/br/com/thalesmachado/kuestioner/KuestionerTest.kt
+++ b/kuestioner/src/test/java/br/com/thalesmachado/kuestioner/KuestionerTest.kt
@@ -80,7 +80,7 @@ class KuestionerTest {
     fun testQueryWithOneParameter() {
         assertEquals("{oneParameter(accountId:12){name}}",
                 getQueryForClass(OneParameter::class.java,
-                        mapOf("accountId" to "12")
+                        mapOf("accountId" to 12)
                 ).query)
     }
 
@@ -93,7 +93,7 @@ class KuestionerTest {
     fun testQueryWithTwoParameters_WithOneNotProvided_ThrowError() {
         try {
             getQueryForClass(TwoParameters::class.java,
-                    mapOf("query1" to "12")
+                    mapOf("query1" to 12)
             )
             failOnExceptionNotThrown()
         } catch (e: IllegalArgumentException) {
@@ -103,10 +103,10 @@ class KuestionerTest {
 
     @Test
     fun testQueryWithTwoParameters() {
-        assertEquals("{twoParameters(query1:12,query2:13){name}}",
+        assertEquals("{twoParameters(query1:12,query2:\"string\"){name}}",
                 getQueryForClass(TwoParameters::class.java,
-                        mapOf("query1" to "12",
-                                "query2" to "13")
+                        mapOf("query1" to 12,
+                                "query2" to "string")
                 ).query)
     }
 


### PR DESCRIPTION
When query param value is a String, it must be wrapped in quotes when building the query, or we'll get `400 Failed to parse GraphQL query` when executing it.